### PR TITLE
If the verb passed to `conjugate` is capitalized, keep it that way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ pattern_unittest_db
 test/pattern_unittest_db
 
 .DS_Store
+.history/

--- a/docassemble_pattern/text/__init__.py
+++ b/docassemble_pattern/text/__init__.py
@@ -2213,13 +2213,19 @@ class Verbs(lazydict):
             v = self[b]
             for i in (i1, i2, i3):
                 if i is not None and 0 <= i < len(v) and v[i]:
-                    return v[i]
+                    if verb[0].isupper():
+                        return v[i].capitalize()
+                    else:
+                        return v[i]
         if kwargs.get("parse", True) is True: # rule-based
             v = self.find_lexeme(b)
             for i in (i1, i2, i3):
                 if i is not None and 0 <= i < len(v) and v[i]:
-                    return v[i]
-
+                    if verb[0].isupper():
+                        return v[i].capitalize()
+                    else:
+                        return v[i]
+                        
     def tenses(self, verb, parse=True):
         """ Returns a list of possible tenses for the given inflected verb.
         """


### PR DESCRIPTION
Checks to see if the verb passed to `docassemble.pattern.en.pluralize()` has an initial capital letter. If it does, the output will also contain an initial capital letter.

This matches the behavior of `noun_plural()` which leaves initial capital letters in place.

See: https://github.com/SuffolkLITLab/docassemble-AssemblyLine/issues/582